### PR TITLE
[#15] feat: LLM 데이트 코스 추천 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/axios": "^4.0.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.0",
         "@nestjs/core": "^11.0.1",
@@ -2205,6 +2206,17 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@nestjs/axios": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.0.tgz",
+      "integrity": "sha512-1cB+Jyltu/uUPNQrpUimRHEQHrnQrpLzVj6dU3dgn6iDDDdahr10TgHFGTmw5VuJ9GzKZsCLDL78VSwJAs/9JQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "axios": "^1.3.1",
+        "rxjs": "^7.0.0"
+      }
+    },
     "node_modules/@nestjs/cli": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.2.tgz",
@@ -4251,7 +4263,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/aws-ssl-profiles": {
@@ -4261,6 +4272,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/b4a": {
@@ -5231,7 +5254,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -5562,7 +5584,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -6628,6 +6649,27 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -6741,7 +6783,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
       "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -6766,7 +6807,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6776,7 +6816,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -9788,6 +9827,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/axios": "^4.0.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.0",
     "@nestjs/core": "^11.0.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { WINSTON_MODULE_PROVIDER, WinstonModule } from 'nest-winston';
 import { winstonConfig } from './logger/winston.config';
 import { CustomLogger } from './logger/custom.logger';
 import { Logger } from 'winston';
+import { LLMModule } from './modules/llm/llm.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { Logger } from 'winston';
       synchronize: process.env.NODE_ENV !== 'production',
     }),
     AuthModule,
+    LLMModule,
     WinstonModule.forRoot(winstonConfig),
   ],
   controllers: [],

--- a/src/common/utils/type-converter.ts
+++ b/src/common/utils/type-converter.ts
@@ -1,0 +1,12 @@
+export class TypeConverter {
+  static convertInstanceValuesToArray(input: any): any {
+    const result: any = {};
+
+    Object.keys(input).forEach((key) => {
+      const value = input[key];
+      result[key] = Array.isArray(value) ? value : [value];
+    });
+
+    return result;
+  }
+}

--- a/src/modules/llm/dto/date-course.request.ts
+++ b/src/modules/llm/dto/date-course.request.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class OptionsRequest {
+  @ApiProperty({
+    description: '옵션 이름',
+    example: '옵션1',
+  })
+  @IsString()
+  optionName: string = '';
+
+  @ApiProperty({
+    description: '옵션 값',
+    example: '값1',
+  })
+  @IsString()
+  optionValue: string = '';
+}
+
+export class DateCourseRequest {
+  @ApiProperty({
+    example: [
+      { optionName: '옵션1', optionValue: '값1' },
+      { optionName: '옵션2', optionValue: '값2' },
+    ],
+    required: false,
+  })
+  @IsArray()
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => OptionsRequest)
+  additionalOptions?: OptionsRequest[] = [];
+}

--- a/src/modules/llm/llm.client.ts
+++ b/src/modules/llm/llm.client.ts
@@ -1,0 +1,84 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { AxiosResponse } from 'axios';
+import { Readable } from 'stream';
+
+interface LLMRequest {
+  llm_type: string;
+  template: string;
+  options: any;
+  secret_key: string;
+}
+
+@Injectable()
+export class LLMClient {
+  private readonly logger = new Logger(LLMClient.name);
+  private readonly llmType: string;
+  private readonly secretKey: string;
+  private readonly streamingRequestEndpoint: string;
+  private readonly baseUrl: string;
+
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly configService: ConfigService,
+  ) {
+    this.llmType = this.configService.get<string>('LLM_TYPE') || 'default-llm';
+    this.secretKey =
+      this.configService.get<string>('LLM_SERVER_SECRET_KEY') ||
+      'default-secret';
+    this.streamingRequestEndpoint =
+      this.configService.get<string>('LLM_SERVER_ENDPOINT_STREAMING') ||
+      '/streaming';
+    this.baseUrl = 'https://hyobin-llm.duckdns.org';
+  }
+
+  receiveLLMStreaming(options: any, template: string): Observable<string> {
+    const llmRequest: LLMRequest = {
+      llm_type: this.llmType,
+      template,
+      options,
+      secret_key: this.secretKey,
+    };
+
+    return this.webClientRequest(this.streamingRequestEndpoint, llmRequest);
+  }
+
+  private webClientRequest(
+    requestEndpoint: string,
+    llmRequest: LLMRequest,
+  ): Observable<string> {
+    const url = `${this.baseUrl}${requestEndpoint}`;
+    console.log(llmRequest);
+    return this.httpService
+      .post(url, llmRequest, {
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'text/event-stream',
+        },
+        responseType: 'stream',
+      })
+      .pipe(
+        switchMap((response: AxiosResponse<Readable>) => {
+          const stream = response.data;
+          let counter = 0;
+          return new Observable<string>((observer) => {
+            stream.on('data', (chunk: Buffer) => {
+              counter++;
+              const chunkStr = chunk.toString();
+              if (counter % 10 === 0) {
+                this.logger.log(`Received chunk: ${chunkStr}`);
+              }
+              observer.next(chunkStr);
+            });
+            stream.on('end', () => observer.complete());
+            stream.on('error', (err) => observer.error(err));
+
+            return () => stream.destroy();
+          });
+        }),
+      );
+  }
+}

--- a/src/modules/llm/llm.controller.ts
+++ b/src/modules/llm/llm.controller.ts
@@ -1,0 +1,87 @@
+import { Controller, Get, Query, Res } from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
+import { LLMClient } from './llm.client';
+import { DateCourseRequest } from './dto/date-course.request';
+import { TypeConverter } from '../../common/utils/type-converter';
+
+@ApiTags('LLM')
+@Controller('llm')
+export class LLMController {
+  private readonly template: string =
+    process.env.LLM_DATE_COURSE_TEMPLATE || '데이트 코스 템플릿';
+
+  constructor(private readonly llmClient: LLMClient) {}
+
+  @ApiOperation({
+    summary: '데이트 코스 추천',
+    description: 'LLM API를 통해 데이트 코스를 추천 받을 수 있습니다.',
+  })
+  @ApiQuery({
+    name: 'timeSlot',
+    description: '시간대',
+    example: '아침 ~ 저녁',
+  })
+  @ApiQuery({
+    name: 'weekend',
+    description: '주말 여부',
+    example: 'true',
+  })
+  @ApiQuery({
+    name: 'transportation',
+    description: '교통수단',
+    example: ['지하철', '버스'],
+    isArray: true,
+  })
+  @ApiQuery({
+    name: 'personnel',
+    description: '인원',
+    example: ['남자 1명', '여자 1명'],
+    isArray: true,
+  })
+  @ApiQuery({
+    name: 'budget',
+    description: '예산',
+    example: '5만 원',
+  })
+  @ApiQuery({
+    name: 'region',
+    description: '지역',
+    example: ['서울', '경기'],
+    isArray: true,
+  })
+  @Get('/date')
+  requestDateCourseLLM(
+    @Query() dateCourseRequest: DateCourseRequest,
+    @Res() response: Response,
+  ): void {
+    const optionsToTransmit =
+      TypeConverter.convertInstanceValuesToArray(dateCourseRequest);
+
+    this.proceedStreamingFromExternalApi(
+      response,
+      this.llmClient,
+      optionsToTransmit,
+      this.template,
+    );
+  }
+
+  private proceedStreamingFromExternalApi(
+    response: Response,
+    llmClient: LLMClient,
+    options: any,
+    template: string,
+  ): void {
+    const responseFlux = llmClient.receiveLLMStreaming(options, template);
+    const subscription = responseFlux.subscribe({
+      next: (chunk) => response.write(`data: ${chunk}\n\n`),
+      error: (err) => {
+        response.write(`에러 발생: ${err}`);
+        response.end();
+      },
+      complete: () => response.end(),
+    });
+
+    response.on('close', () => subscription.unsubscribe());
+  }
+}

--- a/src/modules/llm/llm.module.ts
+++ b/src/modules/llm/llm.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { LLMController } from './llm.controller';
+import { LLMClient } from './llm.client';
+import { ConfigModule } from '@nestjs/config';
+
+@Module({
+  imports: [HttpModule, ConfigModule],
+  controllers: [LLMController],
+  providers: [LLMClient],
+  exports: [LLMClient],
+})
+export class LLMModule {}


### PR DESCRIPTION
## partially resolve #15

## 작업내용

### 의존성
- @nestjs/axios 패키지 설치

### 환경변수
- LLM_TYPE
- LLM_SERVER_SECRET_KEY
- LLM_SERVER_ENDPOINT_STREAMING
- LLM_SERVER_ENDPOINT_SSE
- LLM_DATE_COURSE_TEMPLATE
- CLIENT_URL

### 기능
- RxJS를 통해 기존 LangChain 서버(https://github.com/Hii-aka/AlcongDalcongLLMServer )에서 Streaming 데이터를 받아 오는 기능
- 수신한 데이터를 클라이언트에게 실시간으로 전송하는 기능
- 인스턴스 값 타입을 배열로 변환하는 공통 함수

### API 문서
- Swagger